### PR TITLE
Update the test according to a change in the next version of knitr::kable()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ r:
 env:
   global:
   # don't treat missing suggested packages as error
-  - _R_CHECK_FORCE_SUGGESTS_=false
+  - _R_CHECK_FORCE_SUGGESTS_=false _R_CHECK_TESTS_NLINES_=0
 
 before_install:
   Rscript -e 'update.packages(ask = FALSE)'

--- a/tests/testthat/test_comparedf.R
+++ b/tests/testthat/test_comparedf.R
@@ -604,11 +604,11 @@ test_that("Summary output with attributes and max.print options", {
       ""                                                                             ,
       "Table: Non-identical attributes (3 not shown)"                                ,
       ""                                                                             ,
-      "var.x   var.y   name     attr.x                attr.y              "          ,
-      "------  ------  -------  --------------------  --------------------"          ,
-      "sex     sex     label    NA                    Sex (M/F)           "          ,
-      "sex     sex     levels   c(\"Male\", \"Female\")   c(\"Female\", \"Male\") "  ,
-      "race    race    class    NA                    factor              "
+      "var.x   var.y   name     attr.x           attr.y       "                      ,
+      "------  ------  -------  ---------------  -------------"                      ,
+      "sex     sex     label    NA               Sex (M/F)    "                      ,
+      "sex     sex     levels   Male  , Female   Female, Male "                      ,
+      "race    race    class    NA               factor       "
     )
   )
 })


### PR DESCRIPTION
With https://github.com/yihui/knitr/pull/1827, the columns will be converted to character via `format()` instead of `as.character()`. This change will break the test in this package because of the different behaviors of the two functions:

```r
> as.character(list(1, c(1,2)))
[1] "1"       "c(1, 2)"
> format(list(1, c(1,2)))
[1] "1"    "1, 2"
```