### PR TITLE
Install knitr from Github for now

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,3 +55,4 @@ License: GPL (>= 2)
 RoxygenNote: 7.1.0
 LazyData: true
 Encoding: UTF-8
+Remotes: yihui/knitr


### PR DESCRIPTION
so that tests in `test_comparedf.R` can pass (I'm not sure about the failing `test_modelsum.R`).

You'll need to remove this `Remotes` field for the your next CRAN release. Thanks!